### PR TITLE
Fix: enforce max_participants capacity on signup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Validate activity is not full
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
## Summary

Fixes #9

The `max_participants` field was stored per activity but never enforced during signup, allowing activities to be over-enrolled indefinitely.

## Changes

- Added a capacity check in `signup_for_activity` after the duplicate-enrolment check
- Returns `HTTP 400` with `"Activity is full"` when `len(participants) >= max_participants`
- The existing frontend error display will surface this message to the user automatically

## Testing

To verify manually:
1. Find an activity and fill it to its `max_participants` limit
2. Attempt to sign up one more student — the API should return `400 Activity is full`
3. The available spots shown in the UI should never go below 0